### PR TITLE
Add basic matrix operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # User-specific files
 *.suo
+*.swp
 *.user
 *.userosscache
 *.sln.docstates

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ TUTILS_OBJ=$(ODIR)/$(TUTILS).o
 
 _UNITS= abs.o cosecant.o cosine.o cotangent.o degrad.o equality.o \
 		explog.o factorial.o fcm.o power.o roots.o secant.o sine.o \
-		tangent.o vector.o
+		tangent.o vector.o matrix.o
 OBJECTS=$(patsubst %,$(ODIR)/%,$(_UNITS))
 TESTS=$(patsubst %,$(ODIR)/test_%,$(_UNITS))
 

--- a/include/tmath.hpp
+++ b/include/tmath.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <initializer_list>
 #include <string>
+#include <utility>
 
 namespace TMath {
 // Shortform for long long
@@ -105,10 +106,18 @@ public:
 class Matrix {
 private:
 	std::vector<std::vector<DOUBLE>> elements;
+	std::pair<size_t, size_t> validate(const Matrix&) const;
 public:
 	Matrix(std::initializer_list<std::initializer_list<DOUBLE>>);
 	Matrix(const int& width, const int& height);
 	Matrix(const Matrix& m);
+	std::vector<DOUBLE>& operator[](const int&);
+	bool equal(const Matrix&, const DOUBLE&) const;
+	bool operator==(const Matrix&) const;
+	bool operator!=(const Matrix&) const;
+	size_t width() const;
+	size_t height() const;
+	std::string to_string() const;
 };
 }
 

--- a/include/tmath.hpp
+++ b/include/tmath.hpp
@@ -100,6 +100,15 @@ public:
 	int dim() const;
 	std::string to_string() const;
 };
+
+class Matrix {
+private:
+	std::vector<std::vector<DOUBLE>> elements;
+public:
+	Matrix(std::initializer_list<std::initializer_list<DOUBLE>>);
+	Matrix(const int& d);
+	Matrix(const Matrix& v);
+};
 }
 
 #endif

--- a/include/tmath.hpp
+++ b/include/tmath.hpp
@@ -106,7 +106,7 @@ private:
 	std::vector<std::vector<DOUBLE>> elements;
 public:
 	Matrix(std::initializer_list<std::initializer_list<DOUBLE>>);
-	Matrix(const int& d);
+	Matrix(const int& width, const int& height);
 	Matrix(const Matrix& v);
 };
 }

--- a/include/tmath.hpp
+++ b/include/tmath.hpp
@@ -107,7 +107,7 @@ private:
 public:
 	Matrix(std::initializer_list<std::initializer_list<DOUBLE>>);
 	Matrix(const int& width, const int& height);
-	Matrix(const Matrix& v);
+	Matrix(const Matrix& m);
 };
 }
 

--- a/include/tmath.hpp
+++ b/include/tmath.hpp
@@ -18,6 +18,7 @@ const DOUBLE E =  2.718281828459045235360287471352662497757247093699959574966967
 const DOUBLE EQUAL_EPSILON = 1e-7;
 // Mismatched dimensions error for vectors and matrices
 const std::string DIMENSION_ERROR = "Mismatched dimensions";
+const std::string EMPTY_MATRIX_ERROR = "Empty matrix";
 // Error if the operation is not applicable
 const std::string BAD_OPERATION = "Operation is not applicable";
 // Vector length is equal to zero

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -20,3 +20,9 @@ TMath::Matrix::Matrix(const int& width, const int& height) {
 		elements[index] = std::vector<DOUBLE>(width);
 	}
 }
+
+TMath::Matrix::Matrix(const Matrix& m) {
+	size_t height = m.elements.size();
+	elements = std::vector<std::vector<DOUBLE>>(m.elements.size());
+	for (size_t index = 0; index < height; index++) elements[index] = std::vector<DOUBLE>(m.elements[index]);
+}

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -6,7 +6,7 @@ TMath::Matrix::Matrix(std::initializer_list<std::initializer_list<DOUBLE>> list)
 	if (height < 1) throw TMath::EMPTY_MATRIX_ERROR;
 
 	elements = std::vector<std::vector<DOUBLE>>(height);
-	for (auto& row : list) elements[index++] = std::vector<DOUBLE>(row.size());
+	for (auto& row : list) elements[index++] = std::vector<DOUBLE>(row);
 
 	size_t common = elements[index-1].size();
 	for (auto& row : elements) if (row.size() != common) throw TMath::DIMENSION_ERROR;

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -1,5 +1,5 @@
 #include "tmath.hpp"
-#include <iostream>
+#include <sstream>
 
 TMath::Matrix::Matrix(std::initializer_list<std::initializer_list<DOUBLE>> list) {
 	size_t height = list.size(), index = 0;
@@ -25,4 +25,54 @@ TMath::Matrix::Matrix(const Matrix& m) {
 	size_t height = m.elements.size();
 	elements = std::vector<std::vector<DOUBLE>>(m.elements.size());
 	for (size_t index = 0; index < height; index++) elements[index] = std::vector<DOUBLE>(m.elements[index]);
+}
+
+std::pair<size_t, size_t> TMath::Matrix::validate(const Matrix& m) const {
+	size_t w = width(), h = height();
+	if (m.width() != w || m.height() != h) throw TMath::DIMENSION_ERROR;
+	return std::pair<size_t, size_t>(w, h);
+}
+
+std::vector<TMath::DOUBLE>& TMath::Matrix::operator[](const int& i) {
+	return elements[i];
+}
+
+bool TMath::Matrix::equal(const Matrix& m, const DOUBLE& eps) const {
+	std::pair<size_t, size_t> dimensions = validate(m);
+
+	for (size_t i = 0; i < dimensions.second; i++) for (size_t j = 0; j < dimensions.first; j++) 
+		if (!TMath::equal(elements[i][j], m.elements[i][j], eps)) return false;
+
+	return true;
+}
+
+bool TMath::Matrix::operator==(const Matrix& m) const {
+	return equal(m, EQUAL_EPSILON);
+}
+
+bool TMath::Matrix::operator!=(const Matrix& m) const {
+	return !equal(m, EQUAL_EPSILON);
+}
+	
+size_t TMath::Matrix::width() const {
+	return elements[0].size();
+}
+
+size_t TMath::Matrix::height() const {
+	return elements.size();
+}
+
+std::string TMath::Matrix::to_string() const {
+	size_t w = width(), h = height();
+	std::stringstream stream;
+	stream << "{[";
+	for (size_t i = 0; i < h; i++) {
+		for (size_t j = 0; j < w-1; j++) {
+			stream << elements[i][j] << ", ";
+		}
+		stream << elements[i][w-1];
+		if (i < h-1) stream << "], [";
+	}
+	stream << "]}";
+	return stream.str();
 }

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -3,7 +3,7 @@
 
 TMath::Matrix::Matrix(std::initializer_list<std::initializer_list<DOUBLE>> list) {
 	size_t height = list.size(), index = 0;
-	if (height < 1) throw TMath::DIMENSION_ERROR;
+	if (height < 1) throw TMath::EMPTY_MATRIX_ERROR;
 
 	elements = std::vector<std::vector<DOUBLE>>(height);
 	for (auto& row : list) elements[index++] = std::vector<DOUBLE>(row.size());
@@ -13,7 +13,7 @@ TMath::Matrix::Matrix(std::initializer_list<std::initializer_list<DOUBLE>> list)
 }
 
 TMath::Matrix::Matrix(const int& width, const int& height) {
-	if (width < 1 || height < 1) throw TMath::DIMENSION_ERROR;
+	if (width < 1 || height < 1) throw TMath::EMPTY_MATRIX_ERROR;
 
 	elements = std::vector<std::vector<DOUBLE>>(height);
 	for (size_t index = 0; index < width; index++) {

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -2,12 +2,21 @@
 #include <iostream>
 
 TMath::Matrix::Matrix(std::initializer_list<std::initializer_list<DOUBLE>> list) {
-	size_t width = list.size(), index = 0;
-	if (width < 1) throw TMath::DIMENSION_ERROR;
+	size_t height = list.size(), index = 0;
+	if (height < 1) throw TMath::DIMENSION_ERROR;
 
-	elements = std::vector<std::vector<DOUBLE>>(width);
+	elements = std::vector<std::vector<DOUBLE>>(height);
 	for (auto& row : list) elements[index++] = std::vector<DOUBLE>(row.size());
 
 	size_t common = elements[index-1].size();
 	for (auto& row : elements) if (row.size() != common) throw TMath::DIMENSION_ERROR;
+}
+
+TMath::Matrix::Matrix(const int& width, const int& height) {
+	if (width < 1 || height < 1) throw TMath::DIMENSION_ERROR;
+
+	elements = std::vector<std::vector<DOUBLE>>(height);
+	for (size_t index = 0; index < width; index++) {
+		elements[index] = std::vector<DOUBLE>(width);
+	}
 }

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -1,0 +1,13 @@
+#include "tmath.hpp"
+#include <iostream>
+
+TMath::Matrix::Matrix(std::initializer_list<std::initializer_list<DOUBLE>> list) {
+	size_t width = list.size(), index = 0;
+	if (width < 1) throw TMath::DIMENSION_ERROR;
+
+	elements = std::vector<std::vector<DOUBLE>>(width);
+	for (auto& row : list) elements[index++] = std::vector<DOUBLE>(row.size());
+
+	size_t common = elements[index-1].size();
+	for (auto& row : elements) if (row.size() != common) throw TMath::DIMENSION_ERROR;
+}

--- a/test/matrix.cpp
+++ b/test/matrix.cpp
@@ -4,6 +4,7 @@ This test checks the matrix functionality.
 
 #include "tmath.hpp"
 #include "tmath_test.hpp"
+#include <iostream>
 
 int main(int argc, char const *argv[]) {
 	using TMathTest::assertTrue;
@@ -13,7 +14,35 @@ int main(int argc, char const *argv[]) {
 
 	Matrix nullMatrix1(1, 1);
 	Matrix nullMatrix2{{0}};
+	Matrix identityMatrix{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
 	
+	// Check for constructor errors
+	assertTrue(nullMatrix1 == nullMatrix2, "{{0}} == Matrix(1, 1)");
+	assertTrue(!(nullMatrix1 != nullMatrix2), "!{{0}} != Matrix(1, 1)");
+	assertError([&](){ nullMatrix1 == identityMatrix; }, "Dimension mismatch by 1x1 == 3x3");
+	assertError([&](){ nullMatrix1 != identityMatrix; }, "Dimension mismatch by 1x1 == 3x3");
 	assertError([&](){ Matrix(0, 0); }, "Empty matrix constructor using dimensions");
 	assertError([&](){ Matrix{}; }, "Empty matrix constructor using initializer list");
+
+	// Check for copy constructor
+	assertTrue(identityMatrix == Matrix(identityMatrix), "m == Matrix(m)");
+	assertTrue(nullMatrix1 == Matrix(nullMatrix2), "{{0}} == Matrix({{0}})");
+
+	// Check for access operator
+	assertTrue(nullMatrix1[0][0] == 0, "{{0}}[0][0] == 0");
+	assertTrue(identityMatrix[0][0] == 1, "Identity[0][0] == 1");
+	assertTrue(identityMatrix[1][0] == 0, "Identity[1][0] == 0");
+	assertTrue(identityMatrix[1][1] == 1, "Identity[1][1] == 1");
+
+	// Check for width and heiht
+	assertTrue(nullMatrix1.width() == 1, "{{0}}.width() == 1");
+	assertTrue(nullMatrix2.height() == 1, "Matrix(1, 1).height() == 1");
+	assertTrue(identityMatrix.width() == 3, "Identity.width() == 3");
+	assertTrue(identityMatrix.height() == 3, "Identity.height() == 3");
+
+	// Check for to_string
+	assertTrue(nullMatrix1.to_string() == "{[0]}", "str({{0}}) == '{[0]}'");
+	assertTrue(identityMatrix.to_string() == "{[1, 0, 0], [0, 1, 0], [0, 0, 1]}", "str(Identity) == '{[1, 0, 0], [0, 1, 0], [0, 0, 1]}'");
+
+	return 0;
 }

--- a/test/matrix.cpp
+++ b/test/matrix.cpp
@@ -1,0 +1,19 @@
+/*
+This test checks the matrix functionality.
+*/
+
+#include "tmath.hpp"
+#include "tmath_test.hpp"
+
+int main(int argc, char const *argv[]) {
+	using TMathTest::assertTrue;
+	using TMathTest::assertError;
+	using TMath::DOUBLE;
+	using TMath::Matrix;
+
+	Matrix nullMatrix1(1, 1);
+	Matrix nullMatrix2{{0}};
+	
+	assertError([&](){ Matrix(0, 0); }, "Empty matrix constructor using dimensions");
+	assertError([&](){ Matrix{}; }, "Empty matrix constructor using initializer list");
+}


### PR DESCRIPTION
This branch (see #3) adds support for **matrix construction** using **initializer lists**, a **matrix copy** or **dimension specification**. The matrix structure allows **comparison** (_up to a certain deviation_), **string representation** and **direct element access**.
